### PR TITLE
Handle errors fetching existing merge requests

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -1,5 +1,6 @@
 """This file includes easy APIs to handle GitLab merge requests."""
 
+import sys
 from typing import Optional
 import time
 
@@ -135,11 +136,18 @@ def _get_open_merge_requests():
     per_page = 50
     results = []
     while True:
-        next_page = requests.get("{}?state=opened&page={}&per_page={}".format(
-            global_vars.mr_url, page, per_page),
-                         headers=global_vars.headers)
+        try:
+            next_page = requests.get("{}?state=opened&page={}&per_page={}".format(
+                global_vars.mr_url, page, per_page),
+                             headers=global_vars.headers)
+            next_page.raise_for_status()
+        except (requests.exceptions.HTTPError, requests.exceptions.InvalidHeader) as e:
+            print("Error gathering merge requests, message: {}".format(e))
+            sys.exit(1)
+
         if not next_page.json():
             break
+
         results.append(next_page)
         page += 1
     return results


### PR DESCRIPTION
Currently if someone sets up their token wrong, GitLab will respond with a 4XX error and `_get_open_merge_requests` will fall into an infinite loop until it triggers `SSLError(OSError(24, 'Too many open files')))`.

Handle the non-200 status code and print a helpful error message instead.

Also handles the case of having a non-string token set in `.git/config`.

I note this bucks the trend in this file of doing `raise_for_status` and allowing it to explode. But the current pattern contains a superfluous check of `r.status_code` before setting `r.raise_for_status()`.