### PR TITLE
get_change_id: Add diagnostic output

### DIFF
--- a/gerritlab/utils.py
+++ b/gerritlab/utils.py
@@ -59,7 +59,7 @@ def get_change_id(msg, silent=False):
     if m:
         return m.group(1)
     elif not silent:
-        raise ValueError("Didn't find the Change-Id in the commit message!")
+        raise ValueError("Didn't find the Change-Id in the commit message!\n{}".format(msg))
     else:
         return None
 


### PR DESCRIPTION
If get_change_id doesn't find a Change-Id, include the commit message in the error message so that the user can identify the offending commit.  It would be even better if it mentioned the commit hash but this is a step in the right direction.