### PR TITLE
Optimize git push and API requests

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -7,7 +7,7 @@ import time
 import requests
 import git
 
-from gerritlab import global_vars
+from gerritlab import global_vars, utils
 
 
 class MergeRequest:
@@ -134,6 +134,14 @@ class MergeRequest:
             "{}/{}/commits".format(global_vars.mr_url, self._iid))
         r.raise_for_status()
         return r.json()
+
+    def needs_update(self, commit) -> bool:
+        title, desc = utils.get_msg_title_description(commit.commit.message)
+        return (self.source_branch != commit.source_branch or 
+                self.target_branch != commit.target_branch or 
+                self._title != title or 
+                self._description != desc.strip())
+
 
 def _get_open_merge_requests():
     """Gets all open merge requests in the GitLab repo."""


### PR DESCRIPTION
When the number of patches in a stack grows beyond just a few, the time it takes for gerritlab to perform its operations can become very long (30 seconds or more).

This commit attempts to improve the situation by making the following changes:

* Use a single git push to push all commits to their respective branches.  This is a major time saver.

* Determine whether an MR needs to be updated or created using only the information returned by merge_request.get_all_merge_requests(). Never perform additional MR queries.

This commit removes the old logic that was required to deal with unexpected GitLab auto-merge behavior (FIXME: reference needed).  That problem doesn't seem to happen anymore, which is good because now the code can be much simpler.
