### PR TITLE
Don't rebase after updating a MergeRequest

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -96,11 +96,6 @@ class MergeRequest:
         data = r.json()
         self._iid = data["iid"]
         self._web_url = data["web_url"]
-        # After updating the target branch of an MR (or changes have been made
-        # to the target branch), GitLab sometimes doesn't automatically rebase
-        # its source branch against the new target branch.  Here we push a
-        # mandatory rebase.
-        self.rebase()
 
     def rebase(self):
         """Rebases source_branch of the MR against its target_branch."""


### PR DESCRIPTION
Partially revert #20

Problems:

* Updating the MR will trigger a pipeline, and then the rebase will trigger another, even if the rebase was effectively a no-op.

* others?
