### PR TITLE
After pushing, wait for MRs to stabilize

### DIFF
--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -181,6 +181,10 @@ def create_merge_requests(repo, remote, local_branch):
     with timing("push"):
         remote.push(refspec=refs_to_push, force=True)        
 
+    with timing("stabilize"):
+        for mr in new_mrs+updated_mrs:
+            mr.wait_until_stable()
+
     if len(updated_mrs) == 0 and len(new_mrs) == 0:
         print()
         warn("No updated/new MRs.\n")

--- a/unit_tests/merge_request_test.py
+++ b/unit_tests/merge_request_test.py
@@ -20,11 +20,6 @@ USER = "Yuan Yao"
 EMAIL = "yaoyuannnn@gmail.com"
 
 class MergeRequestTest(unittest.TestCase):
-    # GitLab seems to need a little bit of time before the commits of the
-    # MRs get updated, after new commits are pushed to the branches. This is
-    # the time (in seconds) we'll wait before we validate the MRs.
-    WAIT_TIME_BEFORE_VALIDATE = 10
-
     def setUp(self):
         self._test_project_dir = os.path.join(
             repo_path, GITLAB_TEST_PROJECT_PATH)
@@ -40,7 +35,6 @@ class MergeRequestTest(unittest.TestCase):
         self._local_branch = LOCAL_BRANCH
         self._test_repo.git.checkout(self._local_branch)
         global_vars.ci_mode = True
-        self._wait_before_validate = True
         self._mrs = []
 
     def tearDown(self):
@@ -115,12 +109,6 @@ class MergeRequestTest(unittest.TestCase):
                 self._local_branch, utils.get_change_id(commit.message))
             self._mrs.append(
                 merge_request.get_merge_request(self._remote, source_branch))
-
-        # Wait some time before the validation, in order for GitLab to update
-        # the MRs after seeing new commits.
-        if self._wait_before_validate:
-            time.sleep(MergeRequestTest.WAIT_TIME_BEFORE_VALIDATE)
-            self._wait_before_validate = False
 
         for idx, (mr, commit) in enumerate(zip(self._mrs, commits)):
             validate_mr(


### PR DESCRIPTION
By stabililze we mean that the "changes_count" field of the MR has a value of "1".  This ensures that by the time the "git lab" command terminates, MRs should be fully up-to-date.

Note that this approach will have to be reevaluated if #16 is implemented (which would allow multiple commits to end up in a single MR).

Also:
 unit_tests/merge_request_test.py:
  MergeRequestTest:
   Removed WAIT_TIME_BEFORE_VALIDATE, etc since create_merge_requests()
   now waits for the desired state before returning.
