### PR TITLE
Revert "Fix GitLab glitch in tests when changing an MR's target branch. (#29)"

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -86,7 +86,7 @@ class MergeRequest:
 
     def update(
             self, source_branch=None, target_branch=None, title=None,
-            description=None, state_event=None):
+            description=None):
         if source_branch is not None:
             self._source_branch = source_branch
         if target_branch is not None:
@@ -101,8 +101,6 @@ class MergeRequest:
             "title": self._title,
             "description": self._description,
         }
-        if state_event:
-            data["state_event"] = state_event
         r = global_vars.session.put(
             "{}/{}".format(global_vars.mr_url, self._iid),
             data=data)
@@ -136,15 +134,6 @@ class MergeRequest:
         r.raise_for_status()
         if delete_source_branch:
             self._remote.push(refspec=(":{}".format(self._source_branch)))
-
-    def reload(self):
-        """Reloads the MR by closing and reopening it.
-
-        This can be used to refresh MR status.  Related GitLab issue:
-        https://gitlab.com/gitlab-org/gitlab-foss/-/issues/19026#note_36401573
-        """
-        self.update(state_event="close")
-        self.update(state_event="reopen")
 
     def get_commits(self):
         """Returns a list of commits in this merge request."""

--- a/unit_tests/merge_request_test.py
+++ b/unit_tests/merge_request_test.py
@@ -78,27 +78,6 @@ class MergeRequestTest(unittest.TestCase):
             self.assertTrue(mr != None)
             self.assertEqual(mr.target_branch, target_branch)
             mr_commits = mr.get_commits()
-            if len(mr_commits) != 1:
-                # GitLab can run into this bug (shown below in the example) when
-                # we change an MR's target branch.
-                #
-                # Example:
-                #   main:  commit_a -> commit_b
-                #     |                   |
-                #     v                    \
-                #   branch0 (MR0):          `-> commit_c
-                #     |                            |
-                #     V                             \
-                #   branch1 (MR1):                   `-> commit_d
-                #
-                # In the example, MR1 is stacked on MR0, and MR0 and MR1 should
-                # only show commit_c and commit_d, respectively. A GitLab glitch
-                # can result in commit_c and commit_d both show up in MR1.
-                # Waiting doesn't seem to fix this. Here we reload MR1 to make
-                # commit_c disappear. Related GitLab issue:
-                # https://gitlab.com/gitlab-org/gitlab-foss/-/issues/19026#note_36401573
-                mr.reload()
-                mr_commits = mr.get_commits()
             self.assertEqual(len(mr_commits), 1)
             self.assertEqual(mr_commits[0]["id"], commit.hexsha)
             return mr


### PR DESCRIPTION
This reverts commit 61c4fbf32e04d523ddb43172bf0bd6f47927c4d0 as now #36 #33 have fixed the GitLab issue.