### PR TITLE
DEPRECATE `private_token` in `.gitreview`; use git credential helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,33 +30,76 @@ $ pip install .
 
 ## Set up a .gitreview.
 
-Before using this tool, you need to create a .gitreview file in the root
-directory of your project. It needs to contain info like GitLab project ID and
-a private token that can be used to access the GitLab repo and the GitLab API.
-Current optional configuration flags include `target_branch` and
-`remove_source_branch`. `target_branch` represents the target branch that you
-want the MRs to eventually merge into. By default, `target_branch` is `master`.
-`remove_source_branch` can be used to delete the source branch of an MR once
-it's merged. By default, this is set to `True`.  The following shows an example
-of `.gitreview`:
+Before using this tool, you need to create a `.gitreview` file in the root
+directory of your project.
+
+It must contain:
+
+* `host`: The base URL of the GitLab server.
+* `project_id`: The ID of your project on your GitLab host.
+
+It may optionally contain:
+
+* `target_branch`: the target branch that you want the MRs to eventually merge into. By default, `target_branch` is `master`.
+* `remove_source_branch`: Boolean value, indicating whether the source branch of an MR should be deleted once it's merged. By default, `remove_source_branch` is `True`.
+
+Example `.gitreview`:
 
 ```ini
 [origin]
 host=https://gitlab.example.com
 project_id=1234
-private_token=[your-private-token]
 target_branch=master
 remove_source_branch=True
 ```
 
+## Set up a private token.
 
-The `private_token` can alternatively also be stored in your Git config:
+GerritLab requires a GitLab private token with api access.
+
+You have the option to store it either in:
+
+1. `git config`
+2. [git credential helper](https://git-scm.com/book/en/v2/Git-Tools-Credential-Storage)
+
+### Option 1: Store in git config
+
+To store in your git config:
 
 ```console
 $ git config --global gerritlab.private-token "[your-private-token]"
 # OR
 $ git config --local gerritlab.private-token "[your-private-token]"
 ```
+
+### Option 2: Use a git credential store
+
+A more secure option is to use a **git credential store**.
+
+If you've configured a `credential.helper` in git, then GerritLab will prompt
+you for a username and token and attempt to store it in your credential helper.
+
+This is all that's needed for helpers supporting the `store` action (e.g.,
+osxkeychain, libsecret).
+
+But if you're using a credential store which does NOT support the `store`
+action (e.g., pass-git-helper), then you'll need to manually store your GitLab
+token where GerritLab expects to find it.
+
+GerritLab expects to find credentials stored as the `host` from your `.gitreview`.
+
+For example, if your host is `https://gitlab.com`, GerritLab will look for your GitLab
+username and token in your credential helper under
+`https://gitlab.com/`.
+
+Git credential helpers are available for nearly every operating system and
+password store.
+
+For more details, see:
+* [git-scm's list of credential helpers](https://git-scm.com/doc/credential-helpers)
+* Microsoft's [Git Credential Manager](https://github.com/git-ecosystem/git-credential-manager)
+
+⚠️ **Note**: The [git credential store](https://git-scm.com/docs/git-credential-store) is not recommended because it stores passwords in plaintext.
 
 ## Install Change-Id commit-msg hook.
 We need a commit-msg hook that will add a Change-Id to every commit. This

--- a/gerritlab/git_credentials.py
+++ b/gerritlab/git_credentials.py
@@ -1,0 +1,109 @@
+"""
+git_credentials
+===============
+
+Handle gathering and saving git credentials from git credential helpers.
+"""
+
+import subprocess
+
+from typing import Dict, Optional, Union
+from urllib.parse import urlsplit
+
+INSTANCES: Dict[str, 'GitCredentialStore'] = {}
+
+
+def instance(host: str) -> 'GitCredentialStore':
+    """
+    Builds single GitCredentialStore per host
+
+    :host: is the full URL of the gitlab instance
+    """
+    return INSTANCES.setdefault(host, GitCredentialStore(host))
+
+
+class GitCredentialStore:
+    """
+    A class to interact with git credential store.
+
+    :host: is the full URL of the gitlab instance
+    """
+    def __init__(self, host: str) -> None:
+        # TODO: use host + repo path to support per-repo tokens
+        url = urlsplit(host)
+        self._host = url.netloc
+        self._scheme = url.scheme
+        self._token: Optional[str] = None
+        self._git_credentials: Dict[str, str] = {}
+        self._git_credentials_fetched: bool = False
+
+    def get_token(self) -> Union[str, None]:
+        """
+        Convenience method to get the token from the credential store.
+        """
+        return self.get("password")
+
+    def get(self, key: str, default=None) -> Union[str, None]:
+        """
+        Return key from internal git credentials cache, or default if not found.
+        """
+        if not self._git_credentials_fetched:
+            self._populate_git_credentials(self._call_git_credential_fill())
+            self._git_credentials_fetched = True
+
+        return self._git_credentials.get(key, default)
+
+    def _populate_git_credentials(self, git_credentials_output: str) -> None:
+        """
+        Populate the internal git credentials cache
+        """
+        for line in git_credentials_output.splitlines():
+            if "=" in line:
+                key, value = line.split("=", 1)
+                self._git_credentials[key] = value
+
+    def _call_git_credential_fill(self) -> str:
+        """
+        Look up credentials for the host using git credential fill.
+        """
+        try:
+            git_credentials = subprocess.run(
+                ["git", "credential", "fill"],
+                input=f"protocol={self._scheme}\nhost={self._host}\n\n",
+                text=True,
+                stdout=subprocess.PIPE
+            )
+        except KeyboardInterrupt:
+            return ""
+
+        if git_credentials.returncode != 0:
+            return ""
+
+        # Store the credentials for later use
+        self.git_credential_output = git_credentials.stdout
+
+        return self.git_credential_output
+
+    def save(self) -> None:
+        """
+        Save the token to the git credential store.
+        """
+        self._call_git_credential_approve(self.git_credential_output)
+
+    @staticmethod
+    def _call_git_credential_approve(git_credential_fill_out: str) -> int:
+        """
+        Attempt to save the credentials using git credential store.
+
+        Some credential-helpers (pass-git-helper) do not support saving. The
+        pattern seems to be to exit 0 without printing anything in that case.
+
+        Some credential-helpers print a helpful message to stderr.
+
+        Let's pass through the output to the user, but not treat as an error.
+        """
+        return subprocess.run(
+            ["git", "credential", "approve"],
+            input=git_credential_fill_out,
+            text=True
+        ).returncode

--- a/gerritlab/global_vars.py
+++ b/gerritlab/global_vars.py
@@ -4,6 +4,10 @@ import os
 import configparser
 import requests
 
+from git.config import GitConfigParser
+
+from gerritlab import git_credentials
+
 mr_url = None
 pipeline_url = None
 pipelines_url = None
@@ -14,6 +18,7 @@ username = None
 email = None
 ci_mode = False
 session = None
+host = None
 
 
 def load_config(remote, repo):
@@ -26,29 +31,66 @@ def load_config(remote, repo):
     global global_target_branch
     global remove_source_branch
     global session
+    global host
 
-    username = repo.config_reader().get_value("user", "name")
-    email = repo.config_reader().get_value("user", "email")
-
-    config = configparser.ConfigParser()
     root_dir = repo.git.rev_parse("--show-toplevel")
-    config.read(os.path.join(root_dir, ".gitreview"))
-    configs = config[remote]
-    host = configs["host"]
-    project_id = configs["project_id"]
-    if "GITLAB_PRIVATE_TOKEN" in os.environ:
-        private_token = os.environ["GITLAB_PRIVATE_TOKEN"]
-    elif "private_token" in configs:
-        private_token = configs["private_token"]
-    else:
-        private_token = repo.config_reader().get_value("gerritlab", "private-token")
+    git_config = repo.config_reader()
+
+    username = git_config.get_value("user", "name")
+    email = git_config.get_value("user", "email")
+
+    gitreview = configparser.ConfigParser()
+    gitreview.read(os.path.join(root_dir, ".gitreview"))
+    gitreview_config = gitreview[remote]
+
+    host = gitreview_config["host"]
+    project_id = gitreview_config["project_id"]
+
+    private_token = _get_private_token(host, git_config, gitreview_config)
+
     # Optional configs.
-    if "target_branch" in configs:
-        global_target_branch = configs["target_branch"]
-    if "remove_source_branch" in configs:
-        remove_source_branch = configs.getboolean("remove_source_branch")
+    if "target_branch" in gitreview_config:
+        global_target_branch = gitreview_config["target_branch"]
+    if "remove_source_branch" in gitreview_config:
+        remove_source_branch = gitreview_config.getboolean("remove_source_branch")
     mr_url = "{}/api/v4/projects/{}/merge_requests".format(host, project_id)
     pipeline_url = "{}/api/v4/projects/{}/pipeline".format(host, project_id)
     pipelines_url = "{}/api/v4/projects/{}/pipelines".format(host, project_id)
     session = requests.session()
     session.headers.update({"PRIVATE-TOKEN": private_token})
+
+
+def _get_private_token(host: str,
+                       git_config: GitConfigParser,
+                       gitreview_config: configparser.SectionProxy):
+    """
+    Get the private token from one of several sources in the following order of
+    preference:
+
+    1. The GITLAB_PRIVATE_TOKEN environment variable.
+    2. git config
+    3. git credential storage
+    4. (DEPRECATED) The .gitreview file
+
+    Kind of a messy function, but it hides this complexity from the
+    `load_config` function.
+    """
+    if "GITLAB_PRIVATE_TOKEN" in os.environ:
+        return os.environ["GITLAB_PRIVATE_TOKEN"]
+
+    # Try to get the private token from git config.
+    try:
+        return git_config.get_value("gerritlab", "private-token")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        pass
+
+    # Try to get the private token from git credentials.
+    private_token = git_credentials.instance(host).get_token()
+    if private_token is not None:
+        return private_token
+
+    # DEPRECATED: Try to get the private token from .gitreview file.
+    if "private_token" in gitreview_config:
+        raise RuntimeError("Using private_token from .gitreview file is deprecated.")
+
+    raise SystemExit(f"Unable to find private token for {host}")

--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -6,7 +6,7 @@ import argparse
 from contextlib import contextmanager
 from git.repo import Repo
 
-from gerritlab import utils, global_vars, merge_request, pipeline
+from gerritlab import utils, git_credentials, global_vars, merge_request, pipeline
 from gerritlab.utils import Bcolors, msg_with_color, print_with_color, warn
 from gerritlab.pipeline import PipelineStatus
 
@@ -286,6 +286,9 @@ def main():
     # Merge the MRs if they become mergeable.
     if args.merge:
         merge_merge_requests(remote, local_branch)
-        sys.exit(0)
+    else:
+        create_merge_requests(repo, remote, local_branch)
 
-    create_merge_requests(repo, remote, local_branch)
+    # Since we made it this far, we can assume that if the user is using a
+    # git credential helper, they want to store the credentials.
+    git_credentials.instance(global_vars.host).save()

--- a/unit_tests/git_credentials_test.py
+++ b/unit_tests/git_credentials_test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python
+
+import os
+import pytest
+import sys
+import textwrap
+
+current_dir = os.path.dirname(os.path.abspath(__file__))
+parent_dir = os.path.dirname(current_dir)
+sys.path.append(parent_dir)
+
+from gerritlab import git_credentials
+
+@pytest.fixture
+def git_credential_store():
+    git_credential_store = git_credentials.instance("https://gitlab.com")
+    git_credential_store._git_credentials_fetched = True
+    yield git_credential_store
+
+
+def test_git_instances(git_credential_store):
+    assert git_credentials.instance("https://gitlab.com") is git_credential_store
+
+
+def test_git_credential_store(git_credential_store):
+    fill_output = """
+        protocol=https
+        host=gitlab.com
+        password=hunter2
+        foo=bar
+    """
+    git_credential_store._populate_git_credentials(textwrap.dedent(fill_output))
+    assert git_credential_store.get("password") == "hunter2"
+    assert git_credential_store.get_token() == "hunter2"


### PR DESCRIPTION
Current status: `private_token` is stored in `.gitreview` or in git config files as plaintext.

After this patch: storing a `private_token` in `.gitreview` is DEPRECATED and will print a warning.

And users will be able to store their `private_token` where it's only accessible using their git-credential helper of choice.

Change-Id: Ib1c30fa80f143c00e06829a64aa5bf69c121c018