### PR TITLE
main.py: Separate MR description from gerritlab metadata

### DIFF
--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -125,7 +125,7 @@ def generate_augmented_mr_description(commits_data, commit):
     extra.append(f"* _{target_branch}_")
 
     title, desc = utils.get_msg_title_description(commit.commit.message)
-    return (title, desc + "\n" + "\n".join(extra) + "\n")
+    return (title, desc + "\n---\n".join(extra) + "\n")
 
 
 def create_merge_requests(repo, remote, local_branch):

--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -125,7 +125,7 @@ def generate_augmented_mr_description(commits_data, commit):
     extra.append(f"* _{target_branch}_")
 
     title, desc = utils.get_msg_title_description(commit.commit.message)
-    return (title, desc + "\n---\n".join(extra) + "\n")
+    return (title, desc + "\n---\n" + "\n".join(extra) + "\n")
 
 
 def create_merge_requests(repo, remote, local_branch):


### PR DESCRIPTION
Why:

- It is a little confusing to have the gerritlab metadata presented alongside the MR description without any visual separation

What:

- Add a horizontal line (`---`) to above the "Related MRs" section

Fixes #40

Change-Id: I6f7c48117fd8630b2f973d556859f4f7888c32c5