### PR TITLE
Show proposed update/create operations with prompt

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -37,7 +37,7 @@ class MergeRequest:
         self._title = title
         self._description = description
         self._iid = None
-        self._web_url = None
+        self._web_url = "(new)"
         self._mergeable = False
         self._needs_save = False
 


### PR DESCRIPTION
Why:

- It is better not to be surprised by the output of `git lab` (see issue #49)

What:

- Show the list of proposed MR updates/creations, and prompt the user to proceed
- [misc] set the _web_url property as "(new)" when printing info for an MR that does not yet exist

Fixes #50

Change-Id: I3a758a21ccd46930fe33eabecbec9c57b705b3aa