### PR TITLE
utils: Return local branch if already in correct format

### DIFF
--- a/gerritlab/utils.py
+++ b/gerritlab/utils.py
@@ -67,7 +67,12 @@ def get_change_id(msg, silent=False):
 
 
 def get_remote_branch_name(local_branch, change_id):
-    return "{}-{}".format(local_branch, change_id[1:5])
+    branch_parts = local_branch.split("-")
+    change_id_fragment = change_id[1:5]
+    if branch_parts[-1] == change_id_fragment:
+        # Local branch is already in format {branch-change_id_fragment}
+        return local_branch
+    return "{}-{}".format(local_branch, change_id_fragment)
 
 
 def is_remote_stale(commits, remote_commits):


### PR DESCRIPTION
Why:

- Running `git lab` on a commit that has an existing MR can result in gerritlab creating a new MR (#49). This occurs when the local branch is already in the gerritlab format (e.g. perhaps one ran `glab mr checkout` on a gerritlab-created MR).

What:

- Check if the local branch is already in the {branch}-{change-id} format, and if so, return that rather than returning an incorrect remote branch name

Fixes #49

Change-Id: Icb201f9cc07f930d8ad8dd4eb5bd6c467afa08f2