### PR TITLE
Revised MR source branch naming

### DIFF
--- a/gerritlab/utils.py
+++ b/gerritlab/utils.py
@@ -66,8 +66,8 @@ def get_change_id(msg, silent=False):
         return None
 
 
-def get_remote_branch_name(local_branch, change_id):
-    return "{}-{}".format(local_branch, change_id[1:5])
+def get_remote_branch_name(final_branch, change_id):
+    return "{}-{}".format(final_branch, change_id)
 
 
 def is_remote_stale(commits, remote_commits):


### PR DESCRIPTION
Previously gerritlab pushed commits to branches named after the local branch (or a name supplied on the command line).  Now MR branches are named `<final-target-branch-name>-<fullchangeid>`. `final-target-branch-name` comes from `target_branch` in `.gitreview`, unless an override is supplied on the command line.

Advantages:

* The remote branch names never depend on the developer's local branch name. This means you can rename your local branch without worrying about a new set of MRs being created.

* Using the full Change-Id deals with #39

Closes: #53, #39