### PR TITLE
Make .gitreview file entirely optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,14 @@ $ cd gerritlab
 $ pip install .
 ```
 
-## Set up a .gitreview.
+## (Optional) Set up a .gitreview.
 
-Before using this tool, you need to create a `.gitreview` file in the root
-directory of your project.
+A `.gitreview` file can be created in a repo to configure how Gerritlab 
+operates for a given remote.  The `.gitreview` is an INI file with sections
+naming remotes. In each section the following optional settings are allowed:
 
-It must contain:
-
-* `host`: The base URL of the GitLab server.
-* `project_id`: The ID of your project on your GitLab host.
-
-It may optionally contain:
-
-* `target_branch`: the target branch that you want the MRs to eventually merge into. By default, `target_branch` is `master`.
+* `host`: The base URL of the GitLab server.  By default, this is extracted from the git remote URL.
+* `target_branch`: The target branch that you want the MRs to eventually merge into. By default, `target_branch` is whatever the default branch of the GitLab repo is.
 * `remove_source_branch`: Boolean value, indicating whether the source branch of an MR should be deleted once it's merged. By default, `remove_source_branch` is `True`.
 
 Example `.gitreview`:
@@ -48,10 +43,10 @@ Example `.gitreview`:
 ```ini
 [origin]
 host=https://gitlab.example.com
-project_id=1234
-target_branch=master
+target_branch=main
 remove_source_branch=True
 ```
+
 
 ## Set up a private token.
 

--- a/gerritlab/global_vars.py
+++ b/gerritlab/global_vars.py
@@ -2,12 +2,16 @@
 
 import os
 import configparser
+import re
 import requests
+import urllib
 
 from git.config import GitConfigParser
+from git.repo import Repo
 
 from gerritlab import git_credentials
 
+project_url = None
 mr_url = None
 pipeline_url = None
 pipelines_url = None
@@ -15,16 +19,13 @@ branches_url = None
 headers = None
 global_target_branch = "master"
 remove_source_branch = True
-username = None
-email = None
 ci_mode = False
 session = None
-host = None
+host_url = None
 
 
-def load_config(remote, repo):
-    global username
-    global email
+def load_config(remote, repo: Repo):
+    global project_url
     global mr_url
     global pipeline_url
     global pipelines_url
@@ -33,38 +34,105 @@ def load_config(remote, repo):
     global global_target_branch
     global remove_source_branch
     global session
-    global host
+    global host_url
 
-    root_dir = repo.git.rev_parse("--show-toplevel")
+    root_dir = repo.working_tree_dir
     git_config = repo.config_reader()
 
-    username = git_config.get_value("user", "name")
-    email = git_config.get_value("user", "email")
-
     gitreview = configparser.ConfigParser()
+    # Note, this does not raise an exception if the file is not found.
     gitreview.read(os.path.join(root_dir, ".gitreview"))
-    gitreview_config = gitreview[remote]
+    if remote in gitreview:
+        gitreview_config = gitreview[remote]
+    else:
+        gitreview_config = {}
 
-    host = gitreview_config["host"]
-    project_id = gitreview_config["project_id"]
+    (host_url, quoted_project_path) = _parse_remote_url(
+        repo.remotes[remote].url
+    )
+    host_url = gitreview_config.get("host", host_url)
 
-    private_token = _get_private_token(host, git_config, gitreview_config)
+    private_token = _get_private_token(host_url, git_config, gitreview_config)
 
     # Optional configs.
     if "target_branch" in gitreview_config:
         global_target_branch = gitreview_config["target_branch"]
+    else:
+        global_target_branch = _get_upstream_branch(repo)
+        if not global_target_branch:
+            # FIXME: We should allow the target branch to be specified on the
+            # command line like git-review does.
+            raise SystemExit(
+                f"""
+Could not determine the upstream target branch to push changes to.
+
+To fix this, do one of the following things:
+
+* Set the upstream branch of the local branch using a command like:
+  git branch --set-upstream-to={remote}/<upstream-branch-name>
+
+  Example:
+     git branch --set-upstream-to={remote}/main
+
+OR
+
+* Set the default target branch in a section for the remote in .gitreview:
+
+  [{remote}]
+  target_branch=<upstream-branch-name>
+
+  Example:
+    [{remote}]
+    target_branch=main
+"""
+            )
+
     if "remove_source_branch" in gitreview_config:
         remove_source_branch = gitreview_config.getboolean(
             "remove_source_branch"
         )
-    mr_url = "{}/api/v4/projects/{}/merge_requests".format(host, project_id)
-    pipeline_url = "{}/api/v4/projects/{}/pipeline".format(host, project_id)
-    pipelines_url = "{}/api/v4/projects/{}/pipelines".format(host, project_id)
+
+    project_url = "{}/api/v4/projects/{}".format(host_url, quoted_project_path)
+    mr_url = "{}/api/v4/projects/{}/merge_requests".format(
+        host_url, quoted_project_path
+    )
+    pipeline_url = "{}/api/v4/projects/{}/pipeline".format(
+        host_url, quoted_project_path
+    )
+    pipelines_url = "{}/api/v4/projects/{}/pipelines".format(
+        host_url, quoted_project_path
+    )
     branches_url = "{}/api/v4/projects/{}/repository/branches".format(
-        host, project_id
+        host_url, quoted_project_path
     )
     session = requests.session()
     session.headers.update({"PRIVATE-TOKEN": private_token})
+
+
+def _parse_remote_url(url: str):
+    """
+    Parses the supplied `url` (expected to be a git remote url).
+
+    Returns a tuple containing:
+    0: The base URL of the GitLab host (e.g., "https://gitlab.com")
+    1: The url-quoted path to the repo (e.g. "someuser%2Fsomerepo")
+    """
+
+    m = re.match(r"git@(.*):(.*)", url)
+    if m:
+        url = "https://" + m[1]
+        path = m[2]
+    elif re.match(r"https?://.*", url):
+        p = urllib.parse.urlparse(url)
+        url = f"{p.scheme}://{p.hostname}"
+        path = p.path[1:]
+    else:
+        return None
+
+    m = re.match(r"(.*)\.git$", path)
+    if m:
+        path = m[1]
+    return (url, urllib.parse.quote(path, safe=""))
 
 
 def _get_private_token(
@@ -105,3 +173,19 @@ def _get_private_token(
         )
 
     raise SystemExit(f"Unable to find private token for {host}")
+
+
+def _get_upstream_branch(repo: Repo) -> "str|None":
+    local_branch_name = repo.head.reference.name
+    with repo.config_reader() as conf:
+        section = f'branch "{local_branch_name}"'
+        try:
+            remote_ref = conf.get(section, "merge")
+        except (configparser.NoSectionError, configparser.NoOptionError):
+            return None
+        m = re.match(r"refs/heads/(.*)$", remote_ref)
+        if not m:
+            raise Exception(
+                f"Unexpected remote tracking branch format: {remote_ref}"
+            )
+        return m[1]

--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -365,4 +365,4 @@ def main():
     # Since we made it this far, we can assume that if the user is using a
     # git credential helper, they want to store the credentials.
     if git_credentials.INSTANCES:
-        git_credentials.instance(global_vars.host).save()
+        git_credentials.instance(global_vars.host_url).save()

--- a/unit_tests/misc_test.py
+++ b/unit_tests/misc_test.py
@@ -1,0 +1,33 @@
+import os
+import sys
+import unittest
+from git.repo import Repo
+
+repo = Repo(os.path.realpath(__file__), search_parent_directories=True)
+repo_path = repo.working_tree_dir
+sys.path.append(repo_path)
+from gerritlab import global_vars  # noqa: E402
+
+
+class MiscTest(unittest.TestCase):
+    def test_parse_remote_url(self):
+        (url, quoted_path) = global_vars._parse_remote_url(
+            "git@gitlab.com:user/myrepo.git"
+        )
+        assert url == "https://gitlab.com"
+        assert quoted_path == "user%2Fmyrepo"
+        (url, quoted_path) = global_vars._parse_remote_url(
+            "git@gitlab.com:user/myrepo"
+        )
+        assert url == "https://gitlab.com"
+        assert quoted_path == "user%2Fmyrepo"
+        (url, quoted_path) = global_vars._parse_remote_url(
+            "https://gitlab.com/user/myrepo.git"
+        )
+        assert url == "https://gitlab.com"
+        assert quoted_path == "user%2Fmyrepo"
+        (url, quoted_path) = global_vars._parse_remote_url(
+            "https://gitlab.com/user/myrepo"
+        )
+        assert url == "https://gitlab.com"
+        assert quoted_path == "user%2Fmyrepo"


### PR DESCRIPTION
There were several pieces of information defined in .gitreview that
could be automatically determined or are not needed at all:

* The gitlab host URL (gleaned from the remote's URL)
* The project_id (instead, use url-quoted project path from the remote's URL)
* The default branch (can be queried from the API)
