### PR TITLE
setup.py: Bump to version 2.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="gerritlab",
-    version="1.0.0",
+    version="2.0.0",
     description="Gerrit-like code review for GitLab",
     author="Yuan Yao",
     author_email="yaoyuannnn@gmail.com",


### PR DESCRIPTION
#54 changed how Gerritlab links local commits with merge requests, so bumping the version number to reflect this incompatible change.
