### PR TITLE
Ensure MR is "prepared" before considering it stable.

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -240,11 +240,13 @@ Last detailed_merge_status was {self._detailed_merge_status}.
 
     def wait_until_stable(self, commit):
         """
-        Poll the MR until the "sha" field matches that of `commit`.
+        Poll the MR until the "prepared_at" field is populated
+        and the "sha" field matches that of `commit`.
         """
+
         while True:
             self.refresh()
-            if self._sha == commit.commit.hexsha:
+            if self._prepared_at and self._sha == commit.commit.hexsha:
                 return
             time.sleep(0.500)
 


### PR DESCRIPTION
MergeRequest.wait_until_stable():

  Add the condition that self._prepared_at must be populated.
  A freshly created MR may have a null "prepared_at" field for
  some amount of time.

  xref: https://docs.gitlab.com/ee/api/merge_requests.html#preparation-steps

  Today I experienced test failures because it took about 30 minutes
  for a set of MRs to reach prepared state on gitlab.com.
