### PR TITLE
Do not call remote.fetch() at start of create_merge_requests

### DIFF
--- a/gerritlab/main.py
+++ b/gerritlab/main.py
@@ -190,10 +190,6 @@ def get_commits_data(
 def create_merge_requests(repo: Repo, remote, final_branch):
     """Creates new merge requests on remote."""
 
-    # # Sync up remote branches.
-    # with timing("fetch"):
-    #     remote.fetch(prune=True)
-
     commits_data = get_commits_data(repo, remote, final_branch)
     print_with_color("Commits to be reviewed:", Bcolors.OKCYAN)
     for data in reversed(commits_data):


### PR DESCRIPTION
The call to remote.fetch() takes a noticeable amount of time (about a second for repos that I work with regularly) and makes Gerritlab feel sluggish.  When a developer is in a develop/push/CI-TEST/fix loop, the extra seconds add up without adding value.

Leave it to the user to decide when they want to fetch.

Note: The removal of the call to remote.fetch() actually inadvertently happened in #54.  This commit makes that change official.
