### PR TITLE
Increase _wait_until_mergeable timeout to 120 seconds

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -155,7 +155,7 @@ class MergeRequest:
         )
         r.raise_for_status()
 
-    def _wait_until_mergeable(self, timeout=40):
+    def _wait_until_mergeable(self, timeout=120):
         """
         This method is intended for the test suite only.
         """


### PR DESCRIPTION
gitlab.com has been sluggish lately and needs more time to do its thing.
