### PR TITLE
MergeRequest: Make close and delete methods more robust

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -188,7 +188,7 @@ Last detailed_merge_status was {self._detailed_merge_status}.
             resp = global_vars.session.delete(
                 "{}/{}".format(global_vars.branches_url, self._source_branch)
             )
-            if resp.status_code == 404:
+            if resp.status_code in (400, 404):
                 # It's okay if the branch doesn't exist.
                 return
             resp.raise_for_status()
@@ -205,7 +205,7 @@ Last detailed_merge_status was {self._detailed_merge_status}.
             resp = global_vars.session.delete(
                 "{}/{}".format(global_vars.branches_url, self._source_branch)
             )
-            if resp.status_code == 404:
+            if resp.status_code in (400, 404):
                 # It's okay if the branch doesn't exist.
                 return
             resp.raise_for_status()


### PR DESCRIPTION
Treat a 400 response as OK when attempting to delete the source branch.  This is to avoid cascading errors in test case teardown.
