### PR TITLE
Fix MergeRequest.wait_until_stable() for Gitlab < 16

### DIFF
--- a/gerritlab/merge_request.py
+++ b/gerritlab/merge_request.py
@@ -241,12 +241,20 @@ Last detailed_merge_status was {self._detailed_merge_status}.
     def wait_until_stable(self, commit):
         """
         Poll the MR until the "prepared_at" field is populated
-        and the "sha" field matches that of `commit`.
+        (if the field exists) and the "sha" field matches that of `commit`.
         """
+
+        def is_prepared():
+            # The prepared_at field first appeared in GitLab 16.1.
+            # We allow for it to be missing here to allow for
+            # operation with older GitLab installations.
+            if hasattr(self, "_prepared_at"):
+                return self._prepared_at
+            return True
 
         while True:
             self.refresh()
-            if self._prepared_at and self._sha == commit.commit.hexsha:
+            if is_prepared() and self._sha == commit.commit.hexsha:
                 return
             time.sleep(0.500)
 


### PR DESCRIPTION
Allow for a missing "prepared_at" field in the merge request object.

Closes: #71
