### PR TITLE
Fix a bug in retrieving host url.

### DIFF
--- a/gerritlab/global_vars.py
+++ b/gerritlab/global_vars.py
@@ -124,7 +124,7 @@ def _parse_remote_url(url: str):
         path = m[2]
     elif re.match(r"^(?:https?|ssh)://.*", url):
         p = urllib.parse.urlparse(url)
-        url = f"{p.scheme}://{p.hostname}"
+        url = f"https://{p.hostname}"
         path = p.path[1:]
     else:
         return None


### PR DESCRIPTION
Only https should be used in the GitLab API url.

Change-Id: I732c7ca31e58519c1235bfd58c726a46874f3688