### PR TITLE
Allow overriding the GitLab API host via git config

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A `.gitreview` file can be created in a repo to configure how Gerritlab
 operates for a given remote.  The `.gitreview` is an INI file with sections
 naming remotes. In each section the following optional settings are allowed:
 
-* `host`: The base URL of the GitLab server.  By default, this is extracted from the git remote URL.
+* `host`: The base URL of the GitLab server.  By default, this is extracted from the git remote URL. If the git remote uses a different hostname for SSH than the GitLab HTTP API (so the derived host is wrong), set this explicitly. It can also be set in `git config` (see below), which takes precedence over `.gitreview`.
 * `target_branch`: The target branch that you want the MRs to eventually merge into. By default, `target_branch` is whatever the default branch of the GitLab repo is.
 * `remove_source_branch`: Boolean value, indicating whether the source branch of an MR should be deleted once it's merged. By default, `remove_source_branch` is `True`.
 
@@ -46,6 +46,16 @@ host=https://gitlab.example.com
 target_branch=main
 remove_source_branch=True
 ```
+
+The `host` can also be overridden via `git config`, which is handy when you
+don't want to add a tracked `.gitreview` file to the repo just for local
+tooling:
+
+```console
+$ git config --local gerritlab.host "https://gitlab.example.com"
+```
+
+This takes precedence over the `host` in `.gitreview`.
 
 
 ## Set up a private token.

--- a/gerritlab/global_vars.py
+++ b/gerritlab/global_vars.py
@@ -50,7 +50,16 @@ def load_config(remote, repo: Repo):
     (host_url, quoted_project_path) = _parse_remote_url(
         repo.remotes[remote].url
     )
+    # The host serving the GitLab HTTP API may differ from the host in the git
+    # remote URL (e.g. when SSH and HTTP are served from different hostnames),
+    # so allow the API host to be overridden explicitly. Precedence, highest
+    # first: git config `gerritlab.host` > `.gitreview` `host` > derived from
+    # the remote URL.
     host_url = gitreview_config.get("host", host_url)
+    try:
+        host_url = git_config.get_value("gerritlab", "host")
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        pass
 
     private_token = _get_private_token(host_url, git_config, gitreview_config)
 


### PR DESCRIPTION
The API host was always derived from the git remote URL, but the hostname used for SSH can differ from the one serving the GitLab HTTP API. When they differ, the derived host is wrong, breaking both API calls and credential lookup.

Add a `gerritlab.host` git config key that overrides the derived host, taking precedence over `.gitreview`'s `host`. This mirrors the existing `gerritlab.private-token` key and avoids needing a tracked `.gitreview` file just for local tooling.
