### PR TITLE
2.2.0: Support a per-host gerritlab.<remote-host>.url override

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ A `.gitreview` file can be created in a repo to configure how Gerritlab
 operates for a given remote.  The `.gitreview` is an INI file with sections
 naming remotes. In each section the following optional settings are allowed:
 
-* `host`: The base URL of the GitLab server.  By default, this is extracted from the git remote URL. If the git remote uses a different hostname for SSH than the GitLab HTTP API (so the derived host is wrong), set this explicitly. It can also be set in `git config` (see below), which takes precedence over `.gitreview`.
+* `host`: The base URL of the GitLab server.  By default, this is extracted from the git remote URL. If the git remote uses a different hostname for SSH than the GitLab HTTP API (so the derived URL is wrong), set this explicitly. It can also be set in `git config` (see [Per-host override](#per-host-override) below), which takes precedence over `.gitreview`.
 * `target_branch`: The target branch that you want the MRs to eventually merge into. By default, `target_branch` is whatever the default branch of the GitLab repo is.
 * `remove_source_branch`: Boolean value, indicating whether the source branch of an MR should be deleted once it's merged. By default, `remove_source_branch` is `True`.
 
@@ -47,15 +47,33 @@ target_branch=main
 remove_source_branch=True
 ```
 
-The `host` can also be overridden via `git config`, which is handy when you
-don't want to add a tracked `.gitreview` file to the repo just for local
-tooling:
+### Per-host override
+
+If the hostname in your git remote URL differs from the one serving the GitLab
+HTTP API — for example when SSH and HTTP are served from different hosts — you
+can map a remote host to its API base URL via `git config`:
 
 ```console
-$ git config --local gerritlab.host "https://gitlab.example.com"
+$ git config --global gerritlab.<remote-host>.url "https://<api-host>"
 ```
 
-This takes precedence over the `host` in `.gitreview`.
+Because this is keyed by the remote host, it is safe to set with `--global`:
+it only applies to repos whose remote actually uses `<remote-host>`, leaving
+all other repos untouched. This lets you configure the mapping once for every
+repo on that host, rather than per repo.
+
+For example, to route all repos cloned over SSH from `gitlab-ssh.example.com`
+to the API at `https://gitlab.example.com`:
+
+```console
+$ git config --global gerritlab.gitlab-ssh.example.com.url "https://gitlab.example.com"
+```
+
+The resolution order for the API base URL, highest precedence first, is:
+
+1. `git config` `gerritlab.<remote-host>.url`
+2. `.gitreview` `host`
+3. the URL derived from the git remote
 
 
 ## Set up a private token.

--- a/gerritlab/global_vars.py
+++ b/gerritlab/global_vars.py
@@ -47,19 +47,26 @@ def load_config(remote, repo: Repo):
     else:
         gitreview_config = {}
 
-    (host_url, quoted_project_path) = _parse_remote_url(
+    (derived_host_url, quoted_project_path) = _parse_remote_url(
         repo.remotes[remote].url
     )
-    # The host serving the GitLab HTTP API may differ from the host in the git
+    remote_host = urllib.parse.urlparse(derived_host_url).netloc
+
+    # The URL serving the GitLab HTTP API may differ from the host in the git
     # remote URL (e.g. when SSH and HTTP are served from different hostnames),
-    # so allow the API host to be overridden explicitly. Precedence, highest
-    # first: git config `gerritlab.host` > `.gitreview` `host` > derived from
-    # the remote URL.
+    # so allow the API base URL to be overridden. Precedence, highest first:
+    #
+    #   1. git config `[gerritlab "<remote-host>"] url` -- keyed by the remote
+    #      host, so it is safe to set with `--global`: it only applies to repos
+    #      whose remote uses <remote-host>.
+    #   2. `.gitreview` `host`
+    #   3. the URL derived from the git remote
+    host_url = derived_host_url
     host_url = gitreview_config.get("host", host_url)
-    try:
-        host_url = git_config.get_value("gerritlab", "host")
-    except (configparser.NoSectionError, configparser.NoOptionError):
-        pass
+    host_url = _get_config_value(
+        git_config, f'gerritlab "{remote_host}"', "url", host_url
+    )
+    host_url = _validate_host_url(host_url)
 
     private_token = _get_private_token(host_url, git_config, gitreview_config)
 
@@ -115,6 +122,33 @@ def _parse_remote_url(url: str):
     if m:
         path = m[1]
     return (url, urllib.parse.quote(path, safe=""))
+
+
+def _get_config_value(git_config, section: str, option: str, default):
+    """
+    Returns the value of `section.option` from `git_config`, or `default` if
+    the section or option is not set.
+    """
+    try:
+        return git_config.get_value(section, option)
+    except (configparser.NoSectionError, configparser.NoOptionError):
+        return default
+
+
+def _validate_host_url(url: str) -> str:
+    """
+    Validates that `url` is an http(s) base URL for the GitLab instance and
+    normalizes it by stripping any trailing slash. The path is preserved so
+    that GitLab instances hosted under a subpath (e.g.
+    "https://example.com/gitlab") continue to work.
+    """
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise SystemExit(
+            f"Invalid GitLab URL {url!r}: expected an http(s) URL such as "
+            "'https://gitlab.example.com'."
+        )
+    return url.rstrip("/")
 
 
 def _get_private_token(

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup
 
 setup(
     name="gerritlab",
-    version="2.1.1",
+    version="2.2.0",
     description="Gerrit-like code review for GitLab",
     author="Yuan Yao",
     author_email="yaoyuannnn@gmail.com",


### PR DESCRIPTION
The git config override added previously (`gerritlab.host`) was a single plain key, so setting it globally was too far-reaching: it forced every repo, regardless of its remote, to the same API base URL. Setting it per-repo is tedious when many clones share one host.

Replace it with a per-host override read from git config as `[gerritlab "<remote-host>"] url`, keyed by the host in the repo's git remote. It is safe to set with `--global` because it only applies to repos whose remote uses that host, so a single global entry configures every repo on that host at once (e.g. all repos cloned from a GitLab instance whose SSH host differs from its HTTP/API host).

Also validate the resolved base URL regardless of its source: it must be an http(s) URL, and any trailing slash is stripped. A subpath is preserved so GitLab instances hosted under one (e.g. "https://example.com/gitlab") keep working.

Resolution order, highest first: gerritlab.<remote-host>.url, then .gitreview host, then the URL derived from the git remote.
